### PR TITLE
Support for non existing modules

### DIFF
--- a/autoload/vivi/complete.vim
+++ b/autoload/vivi/complete.vim
@@ -24,11 +24,7 @@ function! vivi#complete#module_name(keyword) abort
   if a:keyword ==# ''
     return ''
   endif
-  let i = strridx(a:keyword, '.')
-  if i ==# -1
-    return a:keyword
-  endif
-  return a:keyword[0:i-1]
+  return a:keyword
 endfunction
 
 function! s:module_functions(label, keyword) abort

--- a/elixir/lib/vivi.ex
+++ b/elixir/lib/vivi.ex
@@ -15,9 +15,12 @@ defmodule Vivi do
   end
 
   def module_functions(module_name) do
-    :"Elixir.#{module_name}"
-    |> Code.get_docs(:docs)
-    |> Enum.map(fn doc -> module_name <> "." <> doc_to_string(doc) end)
+    docs = :"Elixir.#{module_name}"
+            |> Code.get_docs(:docs)
+    case docs do
+      nil -> [module_name]
+      _ -> Enum.map(docs, fn doc -> module_name <> "." <> doc_to_string(doc) end)
+    end
   end
 
   def print_module_functions(module_name) do
@@ -26,3 +29,4 @@ defmodule Vivi do
     |> Enum.each(&IO.puts/1)
   end
 end
+

--- a/elixir/lib/vivi.ex
+++ b/elixir/lib/vivi.ex
@@ -15,12 +15,24 @@ defmodule Vivi do
   end
 
   def module_functions(module_name) do
-    docs = :"Elixir.#{module_name}"
-            |> Code.get_docs(:docs)
-    case docs do
-      nil -> [module_name]
-      _ -> Enum.map(docs, fn doc -> module_name <> "." <> doc_to_string(doc) end)
+    [m_name|m_ending] = String.split(module_name, ".", parts: 2)
+    m_ending = case m_ending do
+      [val] -> val
+      [] -> ""
     end
+    docs = :"Elixir.#{m_name}"
+            |> Code.get_docs(:docs)
+    results = case docs do
+      nil -> [module_name]
+      _ -> Stream.map(docs, fn doc -> doc_to_string(doc) end)
+      |> Stream.filter(fn doc -> if m_ending != "" do
+                                   String.starts_with?(String.downcase(doc), String.downcase(m_ending))
+                                 else doc
+                                 end
+                       end)
+      |> Enum.map(fn doc -> m_name <> "." <> doc end)
+    end
+    results
   end
 
   def print_module_functions(module_name) do


### PR DESCRIPTION
If module doesn't exist, omni complete doesn't throw an error message
